### PR TITLE
Use entity.colorNumber over layer.colorNumber if existing

### DIFF
--- a/lib/toSVG.js
+++ b/lib/toSVG.js
@@ -54,9 +54,11 @@ module.exports = function(parsed) {
       throw new Error('no layer table for layer:' + entity.layer);
     }
 
-    let rgb = colors[layerTable.colorNumber];
+    // TODO: not sure if this prioritization is good (entity color first, layer color as fallback)
+    let colorNumber = ('colorNumber' in entity) ? entity.colorNumber : layerTable.colorNumber;
+    let rgb = colors[colorNumber];
     if (rgb === undefined) {
-      logger.warn("Color index", layerTable.colorNumber, "invalid, defaulting to black");
+      logger.warn("Color index", colorNumber, "invalid, defaulting to black");
       rgb = [0, 0, 0];
     }
 


### PR DESCRIPTION
colorNumber of entities was ignored, only colorNumber of layers was applied.
This fix uses entity.colorNumber if existing and layer.colorNumber as fallback.
Since I'm not sure if this prioritization is fine, I left a TODO there.