### PR TITLE
Remove unused comma of exported svg

### DIFF
--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -74,6 +74,6 @@ export default (parsed) => {
     (-1) + ' ' +
     (bbox.width + 2) + ' ' +
     (bbox.height + 2) + '"'
-  svgString += ' width="100%" height="100%">' + paths + '</svg>'
+  svgString += ' width="100%" height="100%">' + paths.join('') + '</svg>'
   return pd.xml(svgString)
 }


### PR DESCRIPTION
Change previous generated SVG output
```
<svg ...attrs>
    <path ...attrs>,
    <path ...attrs>,
    <path ...attrs>,
    <path ...attrs>
</svg>
```
to
```
<svg ...attrs>
    <path ...attrs>
    <path ...attrs>
    <path ...attrs>
    <path ...attrs>
</svg>
```
So some SVG parser can parse it easier