### PR TITLE
Do not render polyline meshes to SVG

### DIFF
--- a/src/entityToPolyline.js
+++ b/src/entityToPolyline.js
@@ -116,7 +116,9 @@ module.exports = function (entity) {
 
   if ((entity.type === 'LWPOLYLINE') || (entity.type === 'POLYLINE')) {
     polyline = []
-    if (entity.vertices.length) {
+    if (entity.polygonMesh || entity.polyfaceMesh) {
+      // Do not attempt to render meshes
+    } else if (entity.vertices.length) {
       if (entity.closed) {
         entity.vertices = entity.vertices.concat(entity.vertices[0])
       }

--- a/src/handlers/entity/polyline.js
+++ b/src/handlers/entity/polyline.js
@@ -9,6 +9,8 @@ export const process = (tuples) => {
     switch (type) {
       case 70:
         entity.closed = (value & 1) === 1
+        entity.polygonMesh = (value & 16) === 16
+        entity.polyfaceMesh = (value & 64) === 64
         break
       case 39:
         entity.thickness = value

--- a/test/unit/polylines.test.js
+++ b/test/unit/polylines.test.js
@@ -12,6 +12,8 @@ describe('POLYLINE', () => {
     assert.deepEqual(entities[0], {
       closed: true,
       layer: 'DXF',
+      polyfaceMesh: false,
+      polygonMesh: false,
       type: 'POLYLINE',
       vertices: [
         { x: 286, y: 279.9999999999999, z: 0 },


### PR DESCRIPTION
This fixes #24 by not generating any SVG path points for mesh polylines.