### PR TITLE
Correcting typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ and some others are **parsed**, but are **not supported for SVG rendering** (see
 There is an ES5 and ES6 example in the ```examples/``` directory that show how to use the library, but there are 3 basic steps:
 
 1. Parse the DXF contents using ```dxf.parseString(<contents>)```. This will return an object representation of the DXF contents.
-1. Denormalise the entities into an array using ```dxf.denormalize(<parsed>)```. After Step 1, the entities are still in the block hierarchy of the DXF file, denormalizing will create the *resulting* entities with the block transforms applied.
+1. Denormalise the entities into an array using ```dxf.denormalise(<parsed>)```. After Step 1, the entities are still in the block hierarchy of the DXF file, denormalising will create the *resulting* entities with the block transforms applied.
 1. (Optional) Create an SVG using ```dxf.toSVG(<parsed>, <options>)```. Please refer to the SVG section below regarding limitations. Options supported are ```interpolationsPerSplineSegment```, with default = 25, e.g. ```dxf.toSVG(<parsed>, {interpolationsPerSplineSegment: 10})```
 
 ## Running the Examples


### PR DESCRIPTION
This just replaces `denormalize` with `denormalise` in step 2 of the "Getting Started" section, to match the exported function name. This tripped me up when I was trying it out for the first time, so hoping I can save someone else a little time down the road.