### PR TITLE
Removed round10 dependency which uses ShareAlike license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dxf",
-  "version": "4.4.4",
+  "version": "4.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7221,11 +7221,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "round10": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/round10/-/round10-1.0.3.tgz",
-      "integrity": "sha1-hhEPRqEIdKGTHaf91eBtGFeo5NA="
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dxf",
-  "version": "4.4.4",
+  "version": "4.5.4",
   "description": "DXF parser for node/browser",
   "main": "lib/index.js",
   "bin": {
@@ -73,7 +73,6 @@
     "commander": "^2.20.3",
     "lodash": "^4.17.15",
     "pretty-data": "^0.40.0",
-    "round10": "^1.0.3",
     "vecks": "^3.9.0"
   },
   "standard": {

--- a/src/util/bSpline.js
+++ b/src/util/bSpline.js
@@ -1,4 +1,4 @@
-import { round10 } from 'round10'
+import round10 from './round10'
 
 /**
  * Copied and ported to code standard as the b-spline library is not maintained any longer.

--- a/src/util/round10.js
+++ b/src/util/round10.js
@@ -1,0 +1,24 @@
+// This is based on the example code found from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
+// Example code on MDN is public domain or CC0 (your preference) or MIT depending when the
+// example code was added:
+// https://developer.mozilla.org/en-US/docs/MDN/About
+
+export default (value, exp) => {
+  // If the exp is undefined or zero...
+  if (typeof exp === 'undefined' || +exp === 0) {
+    return Math.round(value)
+  }
+  value = +value
+  exp = +exp
+  // If the value is not a number or the exp is not an integer...
+  if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
+    return NaN
+  }
+  // Shift
+  value = value.toString().split('e')
+  value = Math.round(+(value[0] + 'e' + (value[1] ? (+value[1] - exp) : -exp)))
+  // Shift back
+  value = value.toString().split('e')
+  return +(value[0] + 'e' + (value[1] ? (+value[1] + exp) : exp))
+}

--- a/test/unit/round10.test.js
+++ b/test/unit/round10.test.js
@@ -1,0 +1,16 @@
+import expect from 'expect'
+
+import round10 from '../../src/util/round10'
+
+describe('round10', () => {
+  it('works correctly with some numbers', () => {
+    expect(round10(55.55, -1)).toEqual(55.6)
+    expect(round10(55.549, -1)).toEqual(55.5)
+    expect(round10(55, 1)).toEqual(60)
+    expect(round10(54.9, 1)).toEqual(50)
+    expect(round10(-55.55, -1)).toEqual(-55.5)
+    expect(round10(-55.551, -1)).toEqual(-55.6)
+    expect(round10(-55, 1)).toEqual(-50)
+    expect(round10(-55.1, 1)).toEqual(-60)
+  })
+})


### PR DESCRIPTION
I have removed the round10 dependency which uses CreativeCommons ShareAlike license. The
license requires any derivative work to be licensed under a compatible copyleft license which MIT
is not (this package) or any proprietary application using this package.

This is discussed here:
<https://opensource.stackexchange.com/questions/7435/mit-licensed-project-with-cc-by-sa-dependency>

The licensing issue is also pointed out in the issue list of the round10 package:
<https://github.com/jhohlfeld/round10/issues/3>

The MDN license says that only documentation is under ShareAlike license but example code is
either public domain or CC0 or MIT, depending when the example code was added:
<https://developer.mozilla.org/en-US/docs/MDN/About#copyrights_and_licenses>

So to avoid any licensing issues, I have replaced the round10 package (which now distributes the code
under a ShareAlike license) with example code (compatible with MIT & many others) directly from MDN:
<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor#decimal_adjustment>