### PR TITLE
workaround that referred to the behavior of Autodesk DWG True View 2022

### DIFF
--- a/src/getOpacityForEntity.js
+++ b/src/getOpacityForEntity.js
@@ -1,0 +1,7 @@
+export default (entity) => {
+  // workaround: hide special entity
+  if (entity.colorNumber === 0 && entity.lineTypeName === 'ByBlock' && entity.type === 'LINE') {
+    return 0
+  }
+  return 1
+}


### PR DESCRIPTION
Add workaround that referred to the behavior of Autodesk DWG True View 2022.

- Type: LINE, LineType=ByBlock, ColorNumber=0
  - render svg element with stroke-opacity=0
- Type: LWPOLYLINE
  - apply flip x
- Type: ELLIPSE
  - avoid flip x

