### PR TITLE
Add layer to SVG elements if available

### DIFF
--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -272,7 +272,10 @@ export default (parsed) => {
         acc.bbox.expandByPoint(bbox.min)
         acc.bbox.expandByPoint(bbox.max)
       }
-      acc.elements.push(`<g stroke="${rgbToColorAttribute(rgb)}">${element}</g>`)
+      // Add layer as property
+      entity.layer ? 
+        acc.elements.push(`<g stroke="${rgbToColorAttribute(rgb)}" layer="${entity.layer}">${element}</g>`) :
+        acc.elements.push(`<g stroke="${rgbToColorAttribute(rgb)}">${element}</g>`);
     }
     return acc
   }, {


### PR DESCRIPTION
The <g> elements inside the SVG have the property "layer" (whenever possible) with the corresponding value to facilitate filtering elements from the DOM.