### PR TITLE
Avoid importing unused parts of lodash

### DIFF
--- a/src/denormalise.js
+++ b/src/denormalise.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import cloneDeep from 'lodash/cloneDeep'
 
 import logger from './util/logger'
 


### PR DESCRIPTION
By importing cloneDeep from `'lodash/cloneDeep'`, the size of the built file `dist/dxf.js` is reduced from 668 kB to 213 kB.