### PR TITLE
Adds a way to incorporate dashed line into generated svg

### DIFF
--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -272,7 +272,13 @@ export default (parsed) => {
         acc.bbox.expandByPoint(bbox.min)
         acc.bbox.expandByPoint(bbox.max)
       }
-      acc.elements.push(`<g stroke="${rgbToColorAttribute(rgb)}">${element}</g>`)
+      let strokeDashArray = ''
+
+      if (entity.lineTypeName && entity.lineTypeName.toLowerCase() !== 'continuous') {
+        strokeDashArray = 'stroke-dasharray="5,5"'
+      }
+
+      acc.elements.push(`<g stroke="${rgbToColorAttribute(rgb)}" ${strokeDashArray}>${element}</g>`)
     }
     return acc
   }, {


### PR DESCRIPTION
in some use case, dashed line is used to represent bending operations.

in this PR, i add a way to read non-continuous lineTypeName, and if any of an entity doesn't continuous, I add `stroke-dasharray="5,5"` to the generated path / g.

Why strictly only 5,5? Just to simplify the code. It's still better than making it all solid lines in my opinion.

But feel free to make more complex conditional regarding stroke dashline in the future.