### PR TITLE
Add "ATTRIB" entity support

### DIFF
--- a/src/handlers/entities.js
+++ b/src/handlers/entities.js
@@ -14,6 +14,7 @@ import insert from './entity/insert'
 import threeDFace from './entity/threeDFace'
 import dimension from './entity/dimension'
 import text from './entity/text'
+import attrib from './entity/attrib'
 
 const handlers = [
   point,
@@ -28,6 +29,7 @@ const handlers = [
   solid,
   mtext,
   text,
+  attrib,
   insert,
   dimension,
   threeDFace

--- a/src/handlers/entity/attrib.js
+++ b/src/handlers/entity/attrib.js
@@ -1,0 +1,78 @@
+import common from './common'
+
+export const TYPE = 'ATTRIB'
+
+const simpleCodes = {
+  10: 'x',
+  20: 'y',
+  30: 'z',
+  40: 'nominalTextHeight',
+  41: 'refRectangleWidth',
+  71: 'attachmentPoint',
+  72: 'drawingDirection',
+  7: 'styleName',
+  11: 'xAxisX',
+  21: 'xAxisY',
+  31: 'xAxisZ',
+  42: 'horizontalWidth',
+  43: 'verticalHeight',
+  73: 'lineSpacingStyle',
+  44: 'lineSpacingFactor',
+  90: 'backgroundFill',
+  420: 'bgColorRGB0',
+  421: 'bgColorRGB1',
+  422: 'bgColorRGB2',
+  423: 'bgColorRGB3',
+  424: 'bgColorRGB4',
+  425: 'bgColorRGB5',
+  426: 'bgColorRGB6',
+  427: 'bgColorRGB7',
+  428: 'bgColorRGB8',
+  429: 'bgColorRGB9',
+  430: 'bgColorName0',
+  431: 'bgColorName1',
+  432: 'bgColorName2',
+  433: 'bgColorName3',
+  434: 'bgColorName4',
+  435: 'bgColorName5',
+  436: 'bgColorName6',
+  437: 'bgColorName7',
+  438: 'bgColorName8',
+  439: 'bgColorName9',
+  45: 'fillBoxStyle',
+  63: 'bgFillColor',
+  441: 'bgFillTransparency',
+  75: 'columnType',
+  76: 'columnCount',
+  78: 'columnFlowReversed',
+  79: 'columnAutoheight',
+  48: 'columnWidth',
+  49: 'columnGutter',
+  50: 'columnHeights'
+}
+
+export const process = (tuples) => {
+  return tuples.reduce((entity, tuple) => {
+    const type = tuple[0]
+    const value = tuple[1]
+
+    if (simpleCodes[type] !== undefined) {
+      entity[simpleCodes[type]] = value
+    } else if ((type === 1) || (type === 3)) {
+      entity.string += value
+    } else if (type === 50) {
+      // Rotation angle in radians
+      entity.xAxisX = Math.cos(value)
+      entity.xAxisY = Math.sin(value)
+    } else {
+      Object.assign(entity, common(type, value))
+    }
+
+    return entity
+  }, {
+    type: TYPE,
+    string: ''
+  })
+}
+
+export default { TYPE, process }


### PR DESCRIPTION
I found that for a DXF parsing task I was doing, I needed access to ATTRIB entities. They seemed to have the same structure as MTEXT entities, so this was mostly just a copy and paste with some slight modifications.

Unfortunately, I don't have a dxf file that can be made public which I could use to add test cases for ATTRIB parsing. If someone would be able to help me out with generating one, or give me some instructions to generate one, I'd be more than willing to add them.

Thanks!