### PR TITLE
Fix. If the color defined in the entity is 256, the color used should be the one defined in the layer

### DIFF
--- a/src/getRGBForEntity.js
+++ b/src/getRGBForEntity.js
@@ -4,7 +4,8 @@ import logger from './util/logger'
 export default (layers, entity) => {
   const layerTable = layers[entity.layer]
   if (layerTable) {
-    const colorNumber = ('colorNumber' in entity) ? entity.colorNumber : layerTable.colorNumber
+    const colorDefinedInEntity = ('colorNumber' in entity && entity.colorNumber !== 256)
+    const colorNumber = colorDefinedInEntity ? entity.colorNumber : layerTable.colorNumber
     const rgb = colors[colorNumber]
     if (rgb) {
       return rgb

--- a/test/unit/colorbylayer.test.js
+++ b/test/unit/colorbylayer.test.js
@@ -1,0 +1,18 @@
+import expect from 'expect'
+
+import getRGBForEntity from '../../src/getRGBForEntity'
+
+describe('colors', () => {
+  it('Color defined in the entity but with value 256 means that we have to use the color defined in the layer.', () => {
+    const fakeEntity = {
+      layer: "0",
+      colorNumber: 256
+    };
+    const fakeLayers = {
+      "0": {
+        colorNumber: 1
+      }
+    }
+    expect(getRGBForEntity(fakeLayers, fakeEntity)).toEqual([255, 0, 0])
+  })
+})


### PR DESCRIPTION
256 is a special value to say that the color used should be the one defined in the layer.

I've experienced this problem with a DXF file that has red entity (it's rendered red in LibreCAD) but it was rendered in a different color when it was exported to SVG using this library.

[train_with_red_entities.zip](https://github.com/skymakerolof/dxf/files/9254709/train_with_red_entities.zip)

Discussion about colors defined in the entity: [https://groups.google.com/g/comp.cad.autocad/c/onnSe9gdaV8/m/Nm-s-e2WuNEJ](https://groups.google.com/g/comp.cad.autocad/c/onnSe9gdaV8/m/Nm-s-e2WuNEJ
