### PR TITLE
rename bulge to hasBulge to mantain consistency with DXF documentatio…

### DIFF
--- a/src/handlers/entity/hatch.js
+++ b/src/handlers/entity/hatch.js
@@ -116,9 +116,9 @@ export const process = (tuples) => {
         case 72:
           {
             // !Polyline --> 1 = Line; 2 = Circular arc; 3 = Elliptic arc; 4 = Spline
-            // Polyline -->  bulge
+            // Polyline -->  hasBulge
             drawType = parseFloat(value)
-            loop[isPolyline ? 'bulge' : 'edgeType'] = drawType
+            loop[isPolyline ? 'hasBulge' : 'edgeType'] = drawType
             if (!isPolyline) {
               drawEntity = createDrawEntity(drawType)
               loop.entities.push(drawEntity)


### PR DESCRIPTION
Rename `bulge` to `hasBulge` to maintain consistency with DXF documentation:
[Boundary Path Data](https://documentation.help/AutoCAD-DXF/WS1a9193826455f5ff18cb41610ec0a2e719-7a11.htm#WSc30cd3d5faa8f6d8e3b895ffb7556c21-7fec)