### PR TITLE
Avoid pushing in currentEntityTuples if it isn't initialized.

### DIFF
--- a/src/handlers/entities.js
+++ b/src/handlers/entities.js
@@ -56,7 +56,9 @@ export default (tuples) => {
       currentEntityTuples = []
       entityGroups.push(currentEntityTuples)
     }
-    currentEntityTuples.push(tuple)
+    if(typeof currentEntityTuples !== 'undefined'){
+      currentEntityTuples.push(tuple)
+    }
   })
 
   let currentPolyline


### PR DESCRIPTION
The library throws an exception when loading several files generated with DG Nest because it tries to push currentEntityTuples before it is initialized. These files start with type 999 instead of 0.
```
999
DGNestPlus
999
DXF R12 created from "DG Nest" Tangenta Software www.tangenta-software.com
0
SECTION
...
```
Avoiding to push if currentEntityTuples is uninitialized solves the problem.

One of the files that gives an error is file 16 downloadable from https://tangenta-software.com/download/dxf-example-files/