### PR TITLE
fix: Lwpolyline with negative extrusionZ doesn't get flipped properly in toSVG (#147)

### DIFF
--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -29,7 +29,7 @@ const addFlipXIfApplicable = (entity, { bbox, element }) => {
  */
 const polyline = (entity) => {
   const vertices = entityToPolyline(entity)
-  const bbox = vertices.reduce(
+  const bbox0 = vertices.reduce(
     (acc, [x, y]) => acc.expandByPoint({ x, y }),
     new Box2(),
   )
@@ -38,10 +38,14 @@ const polyline = (entity) => {
     acc += point[0] + ',' + point[1]
     return acc
   }, '')
-  // Empirically it appears that flipping horzontally does not apply to polyline
+  const element0 = `<path d="${d}" />`
+  const { bbox, element } = addFlipXIfApplicable(entity, {
+    bbox: bbox0,
+    element: element0,
+  })
   return transformBoundingBoxAndElement(
     bbox,
-    `<path d="${d}" />`,
+    element,
     entity.transforms,
   )
 }

--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -38,6 +38,28 @@ const polyline = (entity) => {
     acc += point[0] + ',' + point[1]
     return acc
   }, '')
+  // Empirically it appears that flipping horozontally does not apply to polyline
+  return transformBoundingBoxAndElement(
+    bbox,
+    `<path d="${d}" />`,
+    entity.transforms,
+  )
+}
+
+/**
+ * Create a <path /> element. Interpolates curved entities.
+ */
+const lwpolyline = (entity) => {
+  const vertices = entityToPolyline(entity)
+  const bbox0 = vertices.reduce(
+    (acc, [x, y]) => acc.expandByPoint({ x, y }),
+    new Box2(),
+  )
+  const d = vertices.reduce((acc, point, i) => {
+    acc += i === 0 ? 'M' : 'L'
+    acc += point[0] + ',' + point[1]
+    return acc
+  }, '')
   const element0 = `<path d="${d}" />`
   const { bbox, element } = addFlipXIfApplicable(entity, {
     bbox: bbox0,
@@ -49,6 +71,7 @@ const polyline = (entity) => {
     entity.transforms,
   )
 }
+
 
 /**
  * Create a <circle /> element for the CIRCLE entity.
@@ -324,9 +347,11 @@ const entityToBoundsAndElement = (entity) => {
       }
     }
     case 'LINE':
-    case 'LWPOLYLINE':
     case 'POLYLINE': {
       return polyline(entity)
+    }
+    case 'LWPOLYLINE': {
+      return lwpolyline(entity)
     }
     default:
       logger.warn('entity type not supported in SVG rendering:', entity.type)

--- a/src/toSVG.js
+++ b/src/toSVG.js
@@ -29,7 +29,7 @@ const addFlipXIfApplicable = (entity, { bbox, element }) => {
  */
 const polyline = (entity) => {
   const vertices = entityToPolyline(entity)
-  const bbox0 = vertices.reduce(
+  const bbox = vertices.reduce(
     (acc, [x, y]) => acc.expandByPoint({ x, y }),
     new Box2(),
   )
@@ -38,7 +38,7 @@ const polyline = (entity) => {
     acc += point[0] + ',' + point[1]
     return acc
   }, '')
-  // Empirically it appears that flipping horozontally does not apply to polyline
+  // Empirically it appears that flipping horizontally does not apply to polyline
   return transformBoundingBoxAndElement(
     bbox,
     `<path d="${d}" />`,
@@ -48,6 +48,7 @@ const polyline = (entity) => {
 
 /**
  * Create a <path /> element. Interpolates curved entities.
+ * lwpolyline is the same as polyline but addFlipXIfApplicable does apply
  */
 const lwpolyline = (entity) => {
   const vertices = entityToPolyline(entity)


### PR DESCRIPTION
Solves #147 